### PR TITLE
Set minimum protocol to SMB2

### DIFF
--- a/app/src/main/java/com/google/android/sambadocumentsprovider/SambaProviderApplication.java
+++ b/app/src/main/java/com/google/android/sambadocumentsprovider/SambaProviderApplication.java
@@ -77,6 +77,7 @@ public class SambaProviderApplication extends Application {
     // hosts -- hosts file and DNS resolution
     // bcast -- NetBIOS broadcast
     mSambaConf.addConfiguration("name resolve order", "wins bcast hosts");
+    mSambaConf.addConfiguration("client min protocol", "SMB2");
     mSambaConf.flushAsDefault(new OnConfigurationChangedListener() {
       @Override
       public void onConfigurationChanged() {


### PR DESCRIPTION
This sets the default configuration to use at least SMB2, instead of defaulting to SMB1. You may want to look into the sub versions of SMB2 to see if this default is correct.