### PR TITLE
Authentication on demand

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
       </intent-filter>
     </provider>
 
+    <activity android:name=".auth.AuthActivity" />
   </application>
 
 </manifest>

--- a/app/src/main/java/com/google/android/sambadocumentsprovider/auth/AuthActivity.java
+++ b/app/src/main/java/com/google/android/sambadocumentsprovider/auth/AuthActivity.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.google.android.sambadocumentsprovider.auth;
+
+import android.app.PendingIntent;
+import android.app.ProgressDialog;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import com.google.android.sambadocumentsprovider.R;
+import com.google.android.sambadocumentsprovider.SambaProviderApplication;
+import com.google.android.sambadocumentsprovider.ShareManager;
+import com.google.android.sambadocumentsprovider.base.AuthFailedException;
+import com.google.android.sambadocumentsprovider.base.OnTaskFinishedCallback;
+import com.google.android.sambadocumentsprovider.nativefacade.SmbClient;
+
+public class AuthActivity extends AppCompatActivity {
+  private static final String TAG = "AuthActivity";
+
+  private static final String SHARE_URI_KEY = "shareUri";
+
+  private EditText mSharePathEditText;
+  private EditText mDomainEditText;
+  private EditText mUsernameEditText;
+  private EditText mPasswordEditText;
+
+  private CheckBox mPinShareCheckbox;
+
+  private ProgressDialog progressDialog;
+
+  private ShareManager mShareManager;
+  private SmbClient mClient;
+
+  private final View.OnClickListener mLoginListener = new View.OnClickListener() {
+    @Override
+    public void onClick(View view) {
+      tryAuth();
+    }
+  };
+
+  private final OnTaskFinishedCallback<Void> callback = new OnTaskFinishedCallback<Void>() {
+    @Override
+    public void onTaskFinished(@Status int status, @Nullable Void item, @Nullable Exception e) {
+      progressDialog.dismiss();
+
+      if (status == SUCCEEDED) {
+        setResult(RESULT_OK);
+        finish();
+      } else {
+        Log.i(TAG, "Authentication failed: ", e);
+
+        showMessage(R.string.credential_error);
+      }
+    }
+  };
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+
+    final Context context = getApplicationContext();
+    mShareManager = SambaProviderApplication.getServerManager(context);
+    mClient = SambaProviderApplication.getSambaClient(context);
+
+    Intent authIntent = getIntent();
+    String shareUri = authIntent.getStringExtra(SHARE_URI_KEY);
+
+    prepareUI(shareUri);
+  }
+
+  private void prepareUI(String shareUri) {
+    mSharePathEditText = (EditText) findViewById(R.id.share_path);
+    mUsernameEditText = (EditText) findViewById(R.id.username);
+    mDomainEditText = (EditText) findViewById(R.id.domain);
+    mPasswordEditText = (EditText) findViewById(R.id.password);
+
+    CheckBox passwordCheckbox = (CheckBox) findViewById(R.id.needs_password);
+    mPinShareCheckbox = (CheckBox) findViewById(R.id.pin_share);
+
+    mSharePathEditText.setText(shareUri);
+    mSharePathEditText.setEnabled(false);
+
+    passwordCheckbox.setVisibility(View.GONE);
+    mPinShareCheckbox.setVisibility(View.VISIBLE);
+
+    Button mLoginButton = (Button) findViewById(R.id.mount);
+    mLoginButton.setText(getResources().getString(R.string.login));
+    mLoginButton.setOnClickListener(mLoginListener);
+
+    final Button cancel = (Button) findViewById(R.id.cancel);
+    cancel.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        finish();
+      }
+    });
+  }
+
+  private void tryAuth() {
+    progressDialog = ProgressDialog.show(
+            this, null, getResources().getString(R.string.authenticating), true);
+
+    final String username = mUsernameEditText.getText().toString();
+    final String password = mPasswordEditText.getText().toString();
+
+    if (username.isEmpty() || password.isEmpty()) {
+      showMessage(R.string.empty_credentials);
+      return;
+    }
+
+    new AuthorizationTask(
+      mSharePathEditText.getText().toString(),
+      username,
+      password,
+      mDomainEditText.getText().toString(),
+      mPinShareCheckbox.isChecked(),
+      mShareManager,
+      mClient,
+      callback).execute();
+  }
+
+  private void showMessage(@StringRes int id) {
+    Snackbar.make(mPinShareCheckbox, id, Snackbar.LENGTH_SHORT).show();
+  }
+
+  public static PendingIntent createAuthIntent(Context context, String shareUri) {
+    Intent authIntent = new Intent();
+    authIntent.setComponent(new ComponentName(
+            context.getPackageName(),
+            AuthActivity.class.getName()));
+    authIntent.putExtra(SHARE_URI_KEY, shareUri);
+
+    return PendingIntent.getActivity(
+            context, 0, authIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+  }
+}

--- a/app/src/main/java/com/google/android/sambadocumentsprovider/auth/AuthorizationTask.java
+++ b/app/src/main/java/com/google/android/sambadocumentsprovider/auth/AuthorizationTask.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.google.android.sambadocumentsprovider.auth;
+
+import android.net.Uri;
+
+import com.google.android.sambadocumentsprovider.ShareManager;
+import com.google.android.sambadocumentsprovider.base.BiResultTask;
+import com.google.android.sambadocumentsprovider.base.OnTaskFinishedCallback;
+import com.google.android.sambadocumentsprovider.document.DocumentMetadata;
+import com.google.android.sambadocumentsprovider.nativefacade.SmbClient;
+
+import java.io.IOException;
+
+class AuthorizationTask extends BiResultTask<Void, Void, Void> {
+  private static final String TAG = "AuthorizationTask";
+
+  private final String mUri;
+  private final String mUser;
+  private final String mPassword;
+  private final String mDomain;
+
+  private final boolean mShouldPin;
+  private final ShareManager mShareManager;
+  private final SmbClient mClient;
+  private final OnTaskFinishedCallback<Void> mCallback;
+
+  AuthorizationTask(String uri, String user, String password, String domain, boolean shouldPin,
+                    ShareManager shareManager, SmbClient client,
+                    OnTaskFinishedCallback<Void> callback) {
+    mUri = uri;
+    mUser = user;
+    mPassword = password;
+    mDomain = domain;
+
+    mShouldPin = shouldPin;
+    mShareManager = shareManager;
+    mClient = client;
+    mCallback = callback;
+  }
+
+  @Override
+  public Void run(Void... voids) throws Exception {
+    final DocumentMetadata shareMetadata = DocumentMetadata.createShare(Uri.parse(mUri));
+
+    final ShareManager.ShareMountChecker mountChecker = new ShareManager.ShareMountChecker() {
+      @Override
+      public void checkShareMounting() throws IOException {
+        shareMetadata.loadChildren(mClient);
+      }
+    };
+
+    mShareManager.addOrUpdateServer(mUri, mDomain, mUser, mPassword, mountChecker, mShouldPin);
+
+    return null;
+  }
+
+  @Override
+  public void onSucceeded(Void aVoid) {
+    mCallback.onTaskFinished(OnTaskFinishedCallback.SUCCEEDED, null, null);
+  }
+
+  @Override
+  public void onFailed(Exception e) {
+    mCallback.onTaskFinished(OnTaskFinishedCallback.FAILED, null, e);
+  }
+}

--- a/app/src/main/java/com/google/android/sambadocumentsprovider/browsing/broadcast/BroadcastUtils.java
+++ b/app/src/main/java/com/google/android/sambadocumentsprovider/browsing/broadcast/BroadcastUtils.java
@@ -137,7 +137,7 @@ class BroadcastUtils {
         final int type = buffer.get();
 
         if (type == FILE_SERVER_NODE_TYPE) {
-          servers.add(serverName);
+          servers.add(serverName.trim());
         }
 
         skipBytes(buffer, 2);

--- a/app/src/main/java/com/google/android/sambadocumentsprovider/document/DocumentMetadata.java
+++ b/app/src/main/java/com/google/android/sambadocumentsprovider/document/DocumentMetadata.java
@@ -310,6 +310,10 @@ public class DocumentMetadata {
     return uri.getPathSegments().isEmpty() && !uri.getAuthority().isEmpty();
   }
 
+  public static boolean isShareUri(Uri uri) {
+    return uri.getPathSegments().size() == 1;
+  }
+
   public static DocumentMetadata fromUri(Uri uri, SmbClient client) throws IOException {
     final List<String> pathSegments = uri.getPathSegments();
     if (pathSegments.isEmpty()) {

--- a/app/src/main/java/com/google/android/sambadocumentsprovider/mount/MountServerActivity.java
+++ b/app/src/main/java/com/google/android/sambadocumentsprovider/mount/MountServerActivity.java
@@ -70,6 +70,8 @@ public class MountServerActivity extends AppCompatActivity {
   private static final String DOMAIN_KEY = "domain";
   private static final String USERNAME_KEY = "username";
   private static final String PASSWORD_KEY = "password";
+  private static final String AUTH_LAUNCH_KEY = "authLaunch";
+
 
   private final OnClickListener mPasswordStateChangeListener = new OnClickListener() {
     @Override
@@ -136,8 +138,8 @@ public class MountServerActivity extends AppCompatActivity {
     mPasswordEditText = (EditText) findViewById(R.id.password);
     mPasswordEditText.setOnKeyListener(mMountKeyListener);
 
-    final Button mount = (Button) findViewById(R.id.mount);
-    mount.setOnClickListener(mMountListener);
+    final Button mMountShareButton = (Button) findViewById(R.id.mount);
+    mMountShareButton.setOnClickListener(mMountListener);
 
     final Button cancel = (Button) findViewById(R.id.cancel);
     cancel.setOnClickListener(new OnClickListener() {
@@ -146,6 +148,8 @@ public class MountServerActivity extends AppCompatActivity {
         finish();
       }
     });
+
+    setNeedsPasswordState(false);
 
     // Set MovementMethod to make it respond to clicks on hyperlinks
     final TextView gplv3Link = (TextView) findViewById(R.id.gplv3_link);
@@ -162,6 +166,7 @@ public class MountServerActivity extends AppCompatActivity {
     }
 
     mSharePathEditText.setText(savedInstanceState.getString(SHARE_PATH_KEY, ""));
+
     final boolean needsPassword = savedInstanceState.getBoolean(NEEDS_PASSWORD_KEY);
     setNeedsPasswordState(needsPassword);
     if (needsPassword) {
@@ -236,7 +241,7 @@ public class MountServerActivity extends AppCompatActivity {
 
     final DocumentMetadata metadata = DocumentMetadata.createShare(host, share);
 
-    if (mShareManager.containsShare(metadata.getUri().toString())) {
+    if (mShareManager.isShareMounted(metadata.getUri().toString())) {
       showMessage(R.string.share_already_mounted);
       return;
     }

--- a/app/src/main/java/com/google/android/sambadocumentsprovider/mount/MountServerTask.java
+++ b/app/src/main/java/com/google/android/sambadocumentsprovider/mount/MountServerTask.java
@@ -70,8 +70,8 @@ class MountServerTask extends BiResultTask<Void, Void, Void> {
 
   @Override
   public Void run(Void... args) throws IOException {
-    mShareManager.mountServer(
-        mMetadata.getUri().toString(), mDomain, mUsername, mPassword, mChecker);
+    mShareManager.addServer(
+        mMetadata.getUri().toString(), mDomain, mUsername, mPassword, mChecker, true);
     return null;
   }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -54,43 +54,53 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/clickable_height"
         android:layout_below="@id/share_path"
+        android:checked="false"
         android:text="@string/needs_password"/>
 
       <LinearLayout
         android:id="@+id/password_hide_group"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         android:orientation="vertical">
+
         <EditText
           android:id="@+id/domain"
           android:layout_width="match_parent"
           android:layout_height="@dimen/clickable_height"
-          android:minLines="1"
-          android:maxLines="1"
+          android:hint="@string/domain"
           android:inputType="text"
-          android:hint="@string/domain"/>
+          android:maxLines="1"
+          android:minLines="1"/>
 
         <EditText
           android:id="@+id/username"
           android:layout_width="match_parent"
           android:layout_height="@dimen/clickable_height"
-          android:minLines="1"
-          android:maxLines="1"
+          android:hint="@string/username"
           android:inputType="text"
-          android:hint="@string/username"/>
+          android:maxLines="1"
+          android:minLines="1"/>
 
         <EditText
           android:id="@+id/password"
           android:layout_width="match_parent"
           android:layout_height="@dimen/clickable_height"
-          android:minLines="1"
-          android:maxLines="1"
-          android:inputType="textPassword"
           android:fontFamily="sans-serif"
-          android:hint="@string/password"/>
+          android:hint="@string/password"
+          android:inputType="textPassword"
+          android:maxLines="1"
+          android:minLines="1"/>
 
       </LinearLayout>
+
+      <CheckBox
+        android:id="@+id/pin_share"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/pin_this_share"
+        android:visibility="gone"/>
+
     </LinearLayout>
   </ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,9 @@
   <string name="no_web_browser">It needs a web browser to send feedback.</string>
 
   <string name="browsing_root_name">Samba Shares</string>
+
+  <string name="pin_this_share">Pin this share</string>
+  <string name="login">Login</string>
+  <string name="authenticating">Authenticating...</string>
+  <string name="empty_credentials">Username and password can not be empty!</string>
 </resources>


### PR DESCRIPTION
Add logic and UI for accessing credential-protected shared.

If authentication is required while browsing shares, the user is sent to an activity where credentials can be entered and verified. There is also an option of mounting the share, which will pin it to the left pane in the file manager.