### PR TITLE
Fix incorrect comparison with assignment

### DIFF
--- a/sambapatch.diff
+++ b/sambapatch.diff
@@ -363,7 +363,7 @@ index 0000000..55a5f1e
 +}
 +
 +static void set_addr(struct ifaddrs_container *ifa, int family, const void *data, size_t byteCount) {
-+  if (ifa->ifa.ifa_addr = NULL) {
++  if (ifa->ifa.ifa_addr == NULL) {
 +    // Assume this is IFA_LOCAL, if not set_local_addr will fix it.
 +    ifa->ifa.ifa_addr = copy_addr(family, data, byteCount, &ifa->addr, ifa->idx);
 +  } else {


### PR DESCRIPTION
This should not set the address when comparing.  Classic C error.  Fixes #66.